### PR TITLE
* Changed Versioning system to support hotfixes

### DIFF
--- a/HellionExtendedServer/App.config
+++ b/HellionExtendedServer/App.config
@@ -1,9 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <section name="HellionExtendedServer.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
-        </sectionGroup>
     </configSections>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
@@ -18,22 +15,6 @@
                </dependentAssembly>
           </assemblyBinding>
     </runtime>
-    <userSettings>
-        <HellionExtendedServer.Properties.Settings>
-            <setting name="AutoStart" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="DebugMode" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="AutoUpdateHes" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="AutoUpdateHellion" serializeAs="String">
-                <value>False</value>
-            </setting>
-        </HellionExtendedServer.Properties.Settings>
-    </userSettings>
     <system.net>
         <settings>
           <httpWebRequest useUnsafeHeaderParsing="true" />

--- a/HellionExtendedServer/HellionExtendedServer.csproj
+++ b/HellionExtendedServer/HellionExtendedServer.csproj
@@ -242,6 +242,7 @@
     <EmbeddedResource Include="Resources\GameServer_example.ini" />
     <EmbeddedResource Include="Resources\NLog.config" />
     <None Include="README.md" />
+    <EmbeddedResource Include="Resources\HellionExtendedServer.exe.config" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/HellionExtendedServer/Managers/Plugins/PluginManager.cs
+++ b/HellionExtendedServer/Managers/Plugins/PluginManager.cs
@@ -187,7 +187,7 @@ namespace HellionExtendedServer.Managers.Plugins
                         {
                             if (IsValidAssembly(file))
                             {
-                                Assembly pluginreference = Assembly.UnsafeLoadFrom(file);
+                                Assembly pluginreference = Assembly.LoadFrom(file);
                                 pluginReferences.Add(pluginreference);
                             }
                             else

--- a/HellionExtendedServer/Modules/Config.cs
+++ b/HellionExtendedServer/Modules/Config.cs
@@ -137,6 +137,7 @@ namespace HellionExtendedServer.Modules
 
         public bool SaveConfiguration()
         {
+
             try
             {
                 using (MemoryStream ms = new MemoryStream())

--- a/HellionExtendedServer/Program.cs
+++ b/HellionExtendedServer/Program.cs
@@ -76,6 +76,8 @@ namespace HellionExtendedServer
             CommandLineArgs = args;
             Console.Title = WindowTitle;
 
+            new FolderStructure().Build();
+
             m_config = new Config();
             debugMode = m_config.Settings.DebugMode;
 
@@ -141,7 +143,7 @@ namespace HellionExtendedServer
 
             Console.ResetColor();
 
-            new FolderStructure().Build();
+           
                                
             updateManager = new UpdateManager();
 
@@ -432,12 +434,19 @@ namespace HellionExtendedServer
 
         internal static void Restart(bool stopServer = true)
         {
-            if (Server.IsRunning && stopServer == true)
-            {
-                if(ServerInstance.Instance != null)
-                    ServerInstance.Instance.Stop();
 
-                SpinWait.SpinUntil(() => !ServerInstance.Instance.IsRunning, 2000);
+            if (Server.Instance != null)
+               
+            {
+                if (Server.IsRunning && stopServer == true)
+                {
+                    if (ServerInstance.Instance != null)
+                    {
+                        ServerInstance.Instance.Stop();
+                        SpinWait.SpinUntil(() => !ServerInstance.Instance.IsRunning, 2000);
+                    }
+                     
+                }                  
             }
 
             var thisProcess = Process.GetCurrentProcess();

--- a/HellionExtendedServer/Properties/AssemblyInfo.cs
+++ b/HellionExtendedServer/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.2.8")]
-[assembly: AssemblyFileVersion("0.1.2.8")]
+[assembly: AssemblyVersion("1.2.1.0")]
+[assembly: AssemblyFileVersion("1.2.1.0")]

--- a/HellionExtendedServer/Properties/Settings.Designer.cs
+++ b/HellionExtendedServer/Properties/Settings.Designer.cs
@@ -22,53 +22,5 @@ namespace HellionExtendedServer.Properties {
                 return defaultInstance;
             }
         }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool AutoStart {
-            get {
-                return ((bool)(this["AutoStart"]));
-            }
-            set {
-                this["AutoStart"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
-        public bool DebugMode {
-            get {
-                return ((bool)(this["DebugMode"]));
-            }
-            set {
-                this["DebugMode"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
-        public bool AutoUpdateHes {
-            get {
-                return ((bool)(this["AutoUpdateHes"]));
-            }
-            set {
-                this["AutoUpdateHes"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool AutoUpdateHellion {
-            get {
-                return ((bool)(this["AutoUpdateHellion"]));
-            }
-            set {
-                this["AutoUpdateHellion"] = value;
-            }
-        }
     }
 }

--- a/HellionExtendedServer/Properties/Settings.settings
+++ b/HellionExtendedServer/Properties/Settings.settings
@@ -1,18 +1,5 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="HellionExtendedServer.Properties" GeneratedClassName="Settings">
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)">
   <Profiles />
-  <Settings>
-    <Setting Name="AutoStart" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
-    </Setting>
-    <Setting Name="DebugMode" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
-    </Setting>
-    <Setting Name="AutoUpdateHes" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
-    </Setting>
-    <Setting Name="AutoUpdateHellion" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
-    </Setting>
-  </Settings>
+  <Settings />
 </SettingsFile>


### PR DESCRIPTION
    * (1.2.1.0) Major.Minor.Build.Revison(aka hotfix)
 * Fixed the Self-Installer throwing a SaveConfiguration exception if the server wasn't ran before changing to use development releases.
 * Fixed the Initial restart after changing to use Development Releases to restart properly if the server wasn't initiated yet